### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -14,7 +14,7 @@ require_once(DOKU_PLUGIN.'action.php');
 
 class action_plugin_nosidebar extends DokuWiki_Action_Plugin {
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'nosidebar', array());
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -23,11 +23,11 @@ class syntax_plugin_nosidebar extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('~~NOSIDEBAR~~', $mode, 'plugin_nosidebar');
     }
  
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         return true;
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == "metadata") {
             // set flag in metadata to disable sidebar in action component
             $renderer->meta['nosidebar'] = true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
